### PR TITLE
mogami: Repartition internal storage

### DIFF
--- a/arch/arm/configs/lx_anzu_defconfig
+++ b/arch/arm/configs/lx_anzu_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_coconut_defconfig
+++ b/arch/arm/configs/lx_coconut_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_haida_defconfig
+++ b/arch/arm/configs/lx_haida_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_hallon_defconfig
+++ b/arch/arm/configs/lx_hallon_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_iyokan_defconfig
+++ b/arch/arm/configs/lx_iyokan_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_mango_defconfig
+++ b/arch/arm/configs/lx_mango_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_satsuma_defconfig
+++ b/arch/arm/configs/lx_satsuma_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_smultron_defconfig
+++ b/arch/arm/configs/lx_smultron_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_urushi_defconfig
+++ b/arch/arm/configs/lx_urushi_defconfig
@@ -650,7 +650,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk"
+CONFIG_CMDLINE="console=ttyMSM2,115200n8 androidboot.hardware=semc androidboot.selinux=permissive earlyprintk mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache),12800k@81920k(boot)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set


### PR DESCRIPTION
We're running out of space in kitkat on /system
and /cache (when art-cache is stored in there)

Let's repartition, giving:
 450mb in /system
 469,5mb in /data
 8mb in /cache

This requires a userspace change to store
dalvik-cache in /data instead of /cache
