### PR TITLE
defconfigs: mogami/zeus: Give all the space to /system

### DIFF
--- a/arch/arm/configs/lx_anzu_defconfig
+++ b/arch/arm/configs/lx_anzu_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_coconut_defconfig
+++ b/arch/arm/configs/lx_coconut_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_haida_defconfig
+++ b/arch/arm/configs/lx_haida_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_hallon_defconfig
+++ b/arch/arm/configs/lx_hallon_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_iyokan_defconfig
+++ b/arch/arm/configs/lx_iyokan_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_mango_defconfig
+++ b/arch/arm/configs/lx_mango_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_phoenix_defconfig
+++ b/arch/arm/configs/lx_phoenix_defconfig
@@ -648,7 +648,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_satsuma_defconfig
+++ b/arch/arm/configs/lx_satsuma_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_smultron_defconfig
+++ b/arch/arm/configs/lx_smultron_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_urushi_defconfig
+++ b/arch/arm/configs/lx_urushi_defconfig
@@ -654,7 +654,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set

--- a/arch/arm/configs/lx_zeus_defconfig
+++ b/arch/arm/configs/lx_zeus_defconfig
@@ -648,7 +648,7 @@ CONFIG_ALIGNMENT_TRAP=y
 # CONFIG_USE_OF is not set
 CONFIG_ZBOOT_ROM_TEXT=0x0
 CONFIG_ZBOOT_ROM_BSS=0x0
-CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:460800k@94720k(system),480768k@555520k(userdata),8192k@1036288k(cache)"
+CONFIG_CMDLINE="androidboot.hardware=semc androidboot.selinux=permissive mtdparts=msm_nand:941568k@94720k(system),8192k@1036288k(cache)"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set


### PR DESCRIPTION
- 450MB is not and will not be enough for lollipop
- /data gets full on ART even with very few apps
- Give the whole space to system, user is going to need a second partition
  on the SD card that will be mounted as /data

Change-Id: I967e612c46ec52cb2b5561edfaa7f4c5a7abf892
