### PR TITLE
make compiler happy

### DIFF
--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -370,7 +370,7 @@ if ($hz eq '--can') {
 	}
 
 	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
+	if (!@val) {
 		@val = compute_values($hz);
 	}
 	output($hz, @val);


### PR DESCRIPTION
Fix for warning:
TIMEC   kernel/timeconst.h
defined(@array) is deprecated at /kernel/semc/msm7x30/kernel/timeconst.pl line 373.
        (Maybe you should just omit the defined()?)
